### PR TITLE
feat: vscode pydantic dataclasses workaround

### DIFF
--- a/clubbi_utils/common/dataclasses.py
+++ b/clubbi_utils/common/dataclasses.py
@@ -1,0 +1,9 @@
+# This is a workaround for pylance issue of not autocompleting when using
+# pydantic.dataclasses.dataclass instead of BaseModel
+# more info here: https://github.com/microsoft/python-language-server/issues/1898#issuecomment-743645817
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING: # pragma: no cover
+    from dataclasses import dataclass
+else:
+    from pydantic.dataclasses import dataclass as dataclass


### PR DESCRIPTION
### What is the purpose of this PR?
It adds a workaround for the issue described [here](https://github.com/samuelcolvin/pydantic/issues/4006) that is: auto complete doesn't work for `pydantic.dataclasses.dataclass` in VS Code.

### How this change should be tested?
Importing this dataclass `from clubbi_utils.dataclasses.dataclass import dataclass` and checking to see if the auto complete works for this decorator.

### Disclaimer
This feature should exist only while [this PR](https://github.com/samuelcolvin/pydantic/pull/4007) or another PR that solves the same issue is included in a new pydantic release.

 ### Change type
* [X] New feature (change, without being a breaking change, that adds a new feature)
