### PR TITLE
feat(lambda_invoker): support for primitive types

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clubbi_utils
-version = 3.2.3
+version = 3.3.0
 
 [options]
 packages = find_namespace:


### PR DESCRIPTION
### Qual o propósito deste pull request?
 Adiciona suport input e output types de primitivos para o lambda invoker.

### Como esta mudança deve ser testada?
Usar o lambda invoker com tipos genéricos

 ### Tipo das mudanças
 * [X] Nova funcionalidade (mudança, sem quebra de contrato, que adiciona um nova funcionalidade)
 