### PR TITLE
feat/s3 storage presigned url

### DIFF
--- a/clubbi_utils/aws/s3_object_storage.py
+++ b/clubbi_utils/aws/s3_object_storage.py
@@ -83,6 +83,16 @@ class S3ObjectStorage:
         }
         await self._client.copy_object(Bucket=self._bucket, Key=self._build_key(destination), CopySource=copy_source)
 
+    async def create_presigned_url(self, key_name: str, expiration: int = 3600) -> str:
+        return await self._client.generate_presigned_url(
+            "get_object",
+            Params=dict(
+                Bucket=self._bucket,
+                Key=key_name,
+            ),
+            ExpiresIn=expiration,
+        )
+
 
 async def _group_chunks_to_min_part_size(in_iter: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
     current_chunk: bytes = b""

--- a/clubbi_utils/aws/s3_object_storage.py
+++ b/clubbi_utils/aws/s3_object_storage.py
@@ -84,6 +84,15 @@ class S3ObjectStorage:
         await self._client.copy_object(Bucket=self._bucket, Key=self._build_key(destination), CopySource=copy_source)
 
     async def create_presigned_url(self, key_name: str, expiration: int = 3600) -> str:
+        """Create a temporary public download url for the given `key_name` and `expiration` in seconds.
+
+        Args:
+            key_name (str): Full path to the object in the bucket
+            expiration (int, optional): Url expiration time in seconds. Defaults to 3600.
+
+        Returns:
+            str: Download url to the object with the given expiration and key_name
+        """
         return await self._client.generate_presigned_url(
             "get_object",
             Params=dict(

--- a/tests/aws/localstack_targets.py
+++ b/tests/aws/localstack_targets.py
@@ -1,14 +1,17 @@
 from aiobotocore import AioSession
-from aiobotocore.client import AioBaseClient
+from aiobotocore.session import ClientCreatorContext
 
 
 class LocalStack:
-    SNS_TARGET = 'http://localhost:4566'
-    SES_TARGET = 'http://localhost:4566'
+    SNS_TARGET = "http://localhost:4566"
+    SES_TARGET = "http://localhost:4566"
 
 
-def create_test_client(session: AioSession, service_name: str) -> AioBaseClient:
-    return session.create_client(service_name, region_name='us-east-1',
-                                 aws_access_key_id='foo', aws_secret_access_key='bar',
-                                 endpoint_url=LocalStack.SES_TARGET
-                                 )
+def create_test_client(session: AioSession, service_name: str) -> ClientCreatorContext:
+    return session.create_client(
+        service_name,
+        region_name="us-east-1",
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+        endpoint_url=LocalStack.SES_TARGET,
+    )

--- a/tests/aws/test_s3_object_storage.py
+++ b/tests/aws/test_s3_object_storage.py
@@ -4,84 +4,91 @@ import asyncio
 import aiobotocore
 from clubbi_utils.aws.s3_object_storage import S3ObjectStorage
 from tests.aws.localstack_targets import create_test_client
+from aiobotocore.client import AioBaseClient
 
 BUCKET_NAME = "test-bucket"
-PREFIX=""
+PREFIX = ""
+
 
 class TestS3ObjectStorage(IsolatedAsyncioTestCase):
-    async def asyncSetUp(self) -> None:
-        super().setUp()    
-        self._session = aiobotocore.get_session()
-        await self._remove_objects()
     
-    async def asyncTearDown(self) -> None:
-        await super().asyncTearDown()
-        await self._remove_objects()
-    
-    async def _remove_objects(self):
-        async with create_test_client(self._session, 's3') as client:
-            paginator = client.get_paginator('list_objects')
-            key_to_delete = []
-            async for result in paginator.paginate(Bucket=BUCKET_NAME, Prefix=PREFIX):
-                for content in result.get('Contents', []):
-                    key_to_delete.append(content["Key"])
-            if key_to_delete:
-                delete_payload = dict(Objects=[dict(Key=key) for key in key_to_delete])
-                await client.delete_objects(Bucket=BUCKET_NAME,  Delete=delete_payload)
-    
-    async def test_put_get_small_file(self):
-        async with create_test_client(self._session, 's3') as client:
-            storage = S3ObjectStorage(client, BUCKET_NAME)
-            key = await storage.put_object("small_file.txt", b"hello world")
-            file = await storage.get_object("small_file.txt")
+    async def _yield_s3_client(self) -> AsyncIterator[AioBaseClient]:
+        async with create_test_client(self._session, "s3") as s3_client:
+            yield s3_client
 
-            self.assertEqual(key, "small_file.txt")
-            self.assertEqual(file, b"hello world")
     
+    async def asyncSetUp(self) -> None:
+        super().setUp()
+        self._session = aiobotocore.get_session()
+        self._s3_client_aiter = self._yield_s3_client()
+        self._client = await self._s3_client_aiter.__anext__()
+        await self._remove_objects()
+
+    async def asyncTearDown(self) -> None:
+        await self._remove_objects()
+        with self.assertRaises(StopAsyncIteration):
+            await self._s3_client_aiter.__anext__()
+        await super().asyncTearDown()
+
+    async def _remove_objects(self):
+        paginator = self._client.get_paginator("list_objects")
+        key_to_delete = []
+        async for result in paginator.paginate(Bucket=BUCKET_NAME, Prefix=PREFIX):
+            for content in result.get("Contents", []):
+                key_to_delete.append(content["Key"])
+        if key_to_delete:
+            delete_payload = dict(Objects=[dict(Key=key) for key in key_to_delete])
+            await self._client.delete_objects(Bucket=BUCKET_NAME, Delete=delete_payload)
+
+    async def test_put_get_small_file(self):
+        storage = S3ObjectStorage(self._client, BUCKET_NAME)
+        key = await storage.put_object("small_file.txt", b"hello world")
+        file = await storage.get_object("small_file.txt")
+
+        self.assertEqual(key, "small_file.txt")
+        self.assertEqual(file, b"hello world")
+
     async def test_put_large_file(self):
-        async def byte_iterator()->AsyncIterator[bytes]:
+        async def byte_iterator() -> AsyncIterator[bytes]:
             yield b"large "
             yield b"hello "
             yield b"world"
-        async with create_test_client(self._session, 's3') as client:
-            storage = S3ObjectStorage(client, BUCKET_NAME)
-            key = await storage.put_object("large_file.txt", byte_iterator())
-            file = await storage.get_object("large_file.txt")
 
-            self.assertEqual(key, "large_file.txt")
-            self.assertEqual(file, b"large hello world")
-    
+        storage = S3ObjectStorage(self._client, BUCKET_NAME)
+        key = await storage.put_object("large_file.txt", byte_iterator())
+        file = await storage.get_object("large_file.txt")
+
+        self.assertEqual(key, "large_file.txt")
+        self.assertEqual(file, b"large hello world")
+
     async def test_read_large_file(self):
-        async with create_test_client(self._session, 's3') as client:
-            storage = S3ObjectStorage(client, BUCKET_NAME)
-            key = await storage.put_object("read_large_file.txt", b"helloworld")
-            chunks = []
-            async for chunk in storage.stream_object("read_large_file.txt", chunk_length=3):
-                chunks.append(chunk)
-            self.assertEqual(key, "read_large_file.txt")
-            self.assertEqual(chunks, [b"hel", b"low", b"orl", b"d"])
-    
+        storage = S3ObjectStorage(self._client, BUCKET_NAME)
+        key = await storage.put_object("read_large_file.txt", b"helloworld")
+        chunks = []
+        async for chunk in storage.stream_object("read_large_file.txt", chunk_length=3):
+            chunks.append(chunk)
+        self.assertEqual(key, "read_large_file.txt")
+        self.assertEqual(chunks, [b"hel", b"low", b"orl", b"d"])
+
     async def test_copy_object(self):
-        async with create_test_client(self._session, 's3') as client:
-            storage = S3ObjectStorage(client, BUCKET_NAME)
-            await storage.put_object("file_to_be_copied.txt", data=b"to be copied")
-            await storage.copy_object("file_to_be_copied.txt", "file_copied.txt")
+        storage = S3ObjectStorage(self._client, BUCKET_NAME)
+        await storage.put_object("file_to_be_copied.txt", data=b"to be copied")
+        await storage.copy_object("file_to_be_copied.txt", "file_copied.txt")
 
-            file_to_be_copied = await storage.get_object("file_to_be_copied.txt")
-            file_copied = await storage.get_object("file_copied.txt")
+        file_to_be_copied = await storage.get_object("file_to_be_copied.txt")
+        file_copied = await storage.get_object("file_copied.txt")
 
-            self.assertEqual(file_to_be_copied, b"to be copied")
-            self.assertEqual(file_copied, file_to_be_copied)
-    
+        self.assertEqual(file_to_be_copied, b"to be copied")
+        self.assertEqual(file_copied, file_to_be_copied)
+
     async def test_list_objects(self):
-        async with create_test_client(self._session, 's3') as client:
-            storage = S3ObjectStorage(client, BUCKET_NAME)
-            self.assertEqual(await storage.list_objects("folder"), [])
-            
-            file_names = [f"folder/file{i}.txt" for i in range(10)]
-            
-            await asyncio.gather(*(storage.put_object(fname, data=b"content")for fname in file_names))
+        storage = S3ObjectStorage(self._client, BUCKET_NAME)
+        self.assertEqual(await storage.list_objects("folder"), [])
 
-            files = await storage.list_objects("folder")
+        file_names = [f"folder/file{i}.txt" for i in range(10)]
 
-            self.assertEqual(files, file_names)
+        await asyncio.gather(*(storage.put_object(fname, data=b"content") for fname in file_names))
+
+        files = await storage.list_objects("folder")
+
+        self.assertEqual(files, file_names)


### PR DESCRIPTION
### Qual o propósito deste pull request?
Adiciona nova funcionalidade na classe `S3ObjectStorage` no qual cria links temporários para objetos no s3, junto com 
testes unitários.
Aproveitando é feita algumas refatorações de uso de métodos privados no caso de teste dessa class.

 ### Como esta mudança deve ser testada?
Importar S3ObjectStorage do clubbi_utils e usar o método `create_presigned_url`.

 ### Tipo das mudanças

 * [X] Nova funcionalidade (mudança, sem quebra de contrato, que adiciona um nova funcionalidade)
 