### PR TITLE
Feat/message as file

### DIFF
--- a/clubbi_utils/slack_messenger.py
+++ b/clubbi_utils/slack_messenger.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Callable, Awaitable, Any
+from typing import TypeVar, Callable, Awaitable, Any, Optional
 
 from pydantic import BaseSettings
 
@@ -20,6 +20,14 @@ class SlackMessenger(AsyncSenderStr):
             channel=self._channel_name,
             text=message,
         )
+
+    async def send_message_as_file(self, content: str, file_name: Optional[str], title: Optional[str],
+                                   message: Optional[str]) -> None:
+        await self._client.files_upload(channel=self._channel_name,
+                                        content=content,
+                                        filename=file_name,
+                                        title=title,
+                                        initial_comment=message)
 
 
 class SlackSettings(BaseSettings):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clubbi_utils
-version = 3.5.0
+version = 3.6.0
 
 [options]
 packages = find_namespace:


### PR DESCRIPTION
### Qual o propósito deste pull request?
Adicionando método na wrapper da API de slack para enviar uma mensagem em um canal como arquivo, para criação de snippets resumidos

 ### Como esta mudança deve ser testada?
Chamar o método send_message_as_file do SlackMessenger, e verificar o snippet criado no canal desejado

 ### Tipo das mudanças
 * [ ] Documentação
 * [ ] Refatoração
 * [ ] Correção de bug (mudança, sem quebra de contrato, que corrige um problema)
 * [x] Nova funcionalidade (mudança, sem quebra de contrato, que adiciona um nova funcionalidade)
 * [ ] Quebra de contrato (correção de bug ou nova funcionalidade que acarreta numa quebra de contrato)