### PR TITLE
feat: get_ssm_secret

### DIFF
--- a/clubbi_utils/aws/get_ssm_secret.py
+++ b/clubbi_utils/aws/get_ssm_secret.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+from typing import Union, List, Type, TypeVar, TypedDict, overload
+from aiobotocore.client import AioBaseClient
+from pydantic import parse_raw_as
+
+
+class GetSecretValueResponse(TypedDict):
+    ARN: str
+    Name: str
+    VersionId: str
+    SecretBinary: bytes
+    SecretString: str
+    VersionStages: List[str]
+    CreatedDate: datetime
+
+
+SECRET_TYPE = TypeVar("SECRET_TYPE")
+
+
+@overload
+async def get_ssm_secret(ssm_client: AioBaseClient, secret_name: str, secret_type: Type[SECRET_TYPE]) -> SECRET_TYPE:
+    pass
+
+
+@overload
+async def get_ssm_secret(ssm_client: AioBaseClient, secret_name: str, secret_type: Type = str) -> str:
+    pass
+
+
+async def get_ssm_secret(
+    ssm_client: AioBaseClient,
+    secret_name: str,
+    secret_type: Type = str,
+) -> Union[str, SECRET_TYPE]:
+    """Gets an AWS Secrets Manager value
+
+    example:
+    ```
+    @with_aws_client("secretsmanager")
+    async def main(ssm_client: AioBaseClient) -> None:
+        my_secret_str = await get_ssm_secret(ssm_client, "my_secret_key")
+        my_secret_dict = await get_ssm_secret(ssm_client, "my_secret_key_dict", Dict[str, Any])
+        my_secret_base_model = await get_ssm_secret(ssm_client, "my_secret_base_model", MyBaseModel)
+
+    ```
+
+    Args:
+        ssm_client (AioBaseClient): aiobotocore cliente
+        secret_name (str): Secret key
+        secret_type (Type, optional): Secret value output. Defaults to str.
+
+    Returns:
+        Union[str, SECRET_TYPE]: Secret value
+    """
+    res: GetSecretValueResponse = await ssm_client.get_secret_value(SecretId=secret_name)
+    secret_string = res["SecretString"]
+    if secret_type == str:
+        return secret_string
+    return parse_raw_as(secret_type, secret_string)

--- a/clubbi_utils/aws/get_ssm_secret.py
+++ b/clubbi_utils/aws/get_ssm_secret.py
@@ -45,7 +45,7 @@ async def get_ssm_secret(
     ```
 
     Args:
-        ssm_client (AioBaseClient): aiobotocore cliente
+        ssm_client (AioBaseClient): aiobotocore client
         secret_name (str): Secret key
         secret_type (Type, optional): Secret value output. Defaults to str.
 

--- a/tests/aws/test_get_ssm_secret.py
+++ b/tests/aws/test_get_ssm_secret.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+from clubbi_utils import json
+from typing import Any, Dict
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from pydantic import BaseModel, ValidationError
+
+from clubbi_utils.aws.get_ssm_secret import GetSecretValueResponse, get_ssm_secret
+
+
+class MyBaseModel(BaseModel):
+    a: str
+    i: int
+
+
+class TestGetSsmSecret(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        await super().asyncSetUp()
+        self._ssm_client = AsyncMock()
+
+    def _set_ssm_client_response(self, secret_string: str) -> None:
+        self._ssm_client.get_secret_value.return_value = GetSecretValueResponse(
+            ARN="",
+            Name="",
+            VersionId="",
+            SecretBinary=b"",
+            SecretString=secret_string,
+            VersionStages=[],
+            CreatedDate=datetime(2022, 2, 2),
+        )
+
+    async def test_successful_ssm_call_on_str(self):
+        self._set_ssm_client_response(secret_value := "Hello World")
+        actual_res = await get_ssm_secret(self._ssm_client, secret_key := "my/secret/name")
+
+        self.assertEqual(actual_res, secret_value)
+        self._ssm_client.get_secret_value.awaited_once_with(SecretId=secret_key)
+
+    async def test_successful_ssm_call_on_dict(self):
+        res = dict(a="a", i=2)
+        self._set_ssm_client_response(json.dumps(res))
+
+        actual_res = await get_ssm_secret(self._ssm_client, "my/secret/name", Dict[str, Any])
+        self.assertEqual(res, actual_res)
+
+    async def test_successful_ssm_call_on_base_model(self):
+        res = MyBaseModel(a="a", i=2)
+        self._set_ssm_client_response(res.json())
+
+        actual_res = await get_ssm_secret(self._ssm_client, "my/secret/name", MyBaseModel)
+        self.assertEqual(res, actual_res)
+
+    async def test_unsuccessful_ssm_call_parse_error(self):
+        self._set_ssm_client_response(json.dumps(dict(a="a")))
+
+        with self.assertRaises(ValidationError):
+            await get_ssm_secret(self._ssm_client, "my/secret/name", MyBaseModel)
+
+    async def test_unsuccessful_ssm_call_aws_error(self):
+        err = self._ssm_client.get_secret_value.side_effect = RuntimeError("Test")
+
+        with self.assertRaises(RuntimeError) as act_err:
+            await get_ssm_secret(self._ssm_client, "my/secret/name")
+
+        self.assertEqual(act_err.exception, err)


### PR DESCRIPTION
### Qual o propósito deste pull request?
Cria uma função chamada `get_ssm_secret` no qual resgata uma secret da AWS e faz parsing do valor dela caso seja desejado pelo usuário

 ### Como esta mudança deve ser testada?

exemplo de codigo:
```python
@with_aws_client("secretsmanager")
    async def main(ssm_client: AioBaseClient) -> None:
        my_secret_str = await get_ssm_secret(ssm_client, "my_secret_key")
        my_secret_dict = await get_ssm_secret(ssm_client, "my_secret_key_dict", Dict[str, Any])
        my_secret_base_model = await get_ssm_secret(ssm_client, "my_secret_base_model", MyBaseModel)
```

 ### Tipo das mudanças
 * [X] Nova funcionalidade (mudança, sem quebra de contrato, que adiciona um nova funcionalidade)
 