### PR TITLE
:sparkles: Add Set type to json.dumps serialization

### DIFF
--- a/clubbi_utils/json.py
+++ b/clubbi_utils/json.py
@@ -1,4 +1,4 @@
-from typing import Union, Any, Callable
+from typing import Union, Any, Callable, Set
 
 from pydantic import BaseModel
 

--- a/clubbi_utils/json.py
+++ b/clubbi_utils/json.py
@@ -12,6 +12,8 @@ try:
             return str(obj)
         if isinstance(obj, BaseModel):
             return obj.dict()
+        if isinstance(obj, Set):
+            return list(obj)
         raise TypeError
 
     def dumps(


### PR DESCRIPTION
### Qual o propósito deste pull request?
Permitir que o `json.dumps` serialize o tipo `Set` do Python. Ao fazê-lo, tratará como uma lista.

 ### Como esta mudança deve ser testada?
Utilizar algum dicionário que possua um valor em `Set` e tentar serializar utilizando `json.dumps`.

 ### Tipo das mudanças
 * [X] Nova funcionalidade (mudança, sem quebra de contrato, que adiciona um nova funcionalidade)