### PR TITLE
:sparkles: Add OPT_NON_STR_KEYS for std python json.dumps

### DIFF
--- a/clubbi_utils/json.py
+++ b/clubbi_utils/json.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 try:
     import orjson
-    from orjson import dumps as _dumps, loads as _loads, OPT_INDENT_2, OPT_SORT_KEYS
+    from orjson import dumps as _dumps, loads as _loads, OPT_INDENT_2, OPT_SORT_KEYS, OPT_NON_STR_KEYS
     from decimal import Decimal
 
     def _serialize_default(obj: Any) -> Any:

--- a/clubbi_utils/json.py
+++ b/clubbi_utils/json.py
@@ -17,13 +17,15 @@ try:
         raise TypeError
 
     def dumps(
-        data: Any, /, pretty: bool = False, sort_keys: bool = False, default: Callable[[Any], Any] = _serialize_default
+        data: Any, /, pretty: bool = False, sort_keys: bool = False, non_str_keys: bool = True, default: Callable[[Any], Any] = _serialize_default
     ) -> str:
         option = 0
         if pretty:
             option |= OPT_INDENT_2
         if sort_keys:
             option |= OPT_SORT_KEYS
+        if non_str_keys:
+            option |= OPT_NON_STR_KEYS
 
         return _dumps(data, option=option, default=default).decode()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clubbi_utils
-version = 3.8.3
+version = 4.0.0
 
 [options]
 packages = find_namespace:


### PR DESCRIPTION
### Qual o propósito deste pull request?
Adiciona o valor `OPT_NON_STR_KEYS` para manter o comportamento padrão do Python quando serializa dicionários com chave em formato "não-string".

 ### Como esta mudança deve ser testada?
```python

from clubbi_utils.json import dumps


d = {"a":{1: ["a", "b", "c"]}}
dumps(d)

>> '{"a":{"1":["a","b","c"]}}'

```

 ### Tipo das mudanças
 * [X] Nova funcionalidade (mudança, sem quebra de contrato, que adiciona um nova funcionalidade)