### PR TITLE
feat!(retry_on_deadlock): recreating session in each retry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ jobs:
       url: https://pypi.org/p/clubbi_utils
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.9
@@ -24,12 +27,14 @@ jobs:
       
       - name: Bump version
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
           NEW_VERSION=${{ github.event.release.tag_name }}
           sed -i "s/version = .*/version = $NEW_VERSION/" setup.cfg
-          git commit -m "build(setup.cfg): bump version to $NEW_VERSION"
-          git push
+      
+      - name: Commit bump version
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "build(setup.cfg): bump version to ${{ github.event.release.tag_name }}"
+          file_pattern: setup.cfg
 
       - id: install-pipenv
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,8 @@ jobs:
       
       - name: Bump version
         run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           NEW_VERSION=${{ github.event.release.tag_name }}
           sed -i "s/version = .*/version = $NEW_VERSION/" setup.cfg
           git commit -m "build(setup.cfg): bump version to $NEW_VERSION"

--- a/tests/postgres/test_retry_query_on_deadlock.py
+++ b/tests/postgres/test_retry_query_on_deadlock.py
@@ -1,32 +1,62 @@
+from typing import Any, Optional
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, call
 from sqlalchemy.engine import Result
 from sqlalchemy.exc import DBAPIError
 
-from sqlalchemy.ext.asyncio import AsyncConnection
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 from sqlalchemy.sql import Executable
 
 from clubbi_utils.postgres.retry_query_on_deadlock import retry_query_on_deadlock
 
 
+class AsyncContextManagerMock:
+    def __init__(self, aenter_return: AsyncMock) -> None:
+        self._aenter_return = aenter_return
+
+    async def __aenter__(self) -> AsyncMock:
+        return self._aenter_return
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+
 class TestRetryQueryOnDeadlock(IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:
         self._conn = AsyncMock(spec=AsyncConnection)
+        self._engine = AsyncMock(spec=AsyncEngine)
+        self._engine.begin.side_effect = lambda: AsyncContextManagerMock(self._conn)
         self._statement = MagicMock(spec=Executable)
         self._dbapi_error_deadlock = DBAPIError("", "", orig=MagicMock(pgcode="40P01"))
         self._dbapi_error_other_error = DBAPIError("", "", orig=MagicMock(pgcode="21000"))
         self._result_mock = MagicMock(spec=Result)
 
-    async def _run(self, maximum_number_of_retries: int, expected_number_of_execute_awaits: int) -> None:
-        res = await retry_query_on_deadlock(self._conn, self._statement, maximum_number_of_retries)
+    async def _run(
+        self,
+        maximum_number_of_retries: int,
+        expected_number_of_execute_awaits: int,
+        parameters: Optional[Any] = None,
+    ) -> None:
+        res = await retry_query_on_deadlock(self._engine, self._statement, parameters, maximum_number_of_retries)
         self.assertEqual(res, self._result_mock)
-        self._conn.execute.assert_has_awaits(call(self._statement) for _ in range(expected_number_of_execute_awaits))
+        self._conn.execute.assert_has_awaits(
+            call(self._statement, parameters) for _ in range(expected_number_of_execute_awaits)
+        )
+        self._engine.begin.assert_has_calls(call() for _ in range(expected_number_of_execute_awaits))
 
     async def test_retry_on_deadlock_no_errors(self) -> None:
         self._conn.execute.return_value = self._result_mock
         await self._run(
             maximum_number_of_retries=8,
             expected_number_of_execute_awaits=1,
+        )
+
+    async def test_retry_on_deadlock_no_errors_with_parameters(self) -> None:
+        self._conn.execute.return_value = self._result_mock
+        await self._run(
+            maximum_number_of_retries=8,
+            expected_number_of_execute_awaits=1,
+            parameters={"hello": "world"},
         )
 
     async def test_retry_on_deadlock_after_too_many_attempts(self) -> None:
@@ -38,7 +68,7 @@ class TestRetryQueryOnDeadlock(IsolatedAsyncioTestCase):
                 expected_number_of_execute_awaits=0,
             )
         self.assertEqual(e.exception, self._dbapi_error_deadlock)
-        self._conn.execute.assert_has_awaits(call(self._statement) for _ in range(maximum_number_of_retries))
+        self._conn.execute.assert_has_awaits(call(self._statement, None) for _ in range(maximum_number_of_retries))
 
     async def test_retry_on_deadlock_unknown_error(self) -> None:
         self._conn.execute.side_effect = self._dbapi_error_other_error


### PR DESCRIPTION
Changes the function retry_query_on_deadlock to recreate a session in each retry made, this is due to how postgres sets the session status after an error occurs, and fixes CI when releasing new versions