### PR TITLE
feat: using jlogger in with_timeit

### DIFF
--- a/clubbi_utils/common/timeit.py
+++ b/clubbi_utils/common/timeit.py
@@ -1,27 +1,30 @@
 import time
 from inspect import iscoroutinefunction
+from typing import Callable
+from clubbi_utils.json_logging import jlogger
 
-from clubbi_utils.logging import logger
 
-
-def with_timeit(f):
+def _log(f: Callable, begin: float, end: float) -> None:
     meta = dict(
         qualname=f.__qualname__,
-        __module__=f.__module__,
+        module=f.__module__,
     )
+    jlogger.info(f.__name__, "time_elapsed", duration=end - begin, meta=meta)
 
+
+def with_timeit(f: Callable) -> Callable:
     def wrapper(*args, **kwargs):
         begin = time.time()
         r = f(*args, **kwargs)
         end = time.time()
-        logger.info(dict(name=f.__name__, duration=end - begin, meta=meta))
+        _log(f, begin, end)
         return r
 
     async def async_wrapper(*args, **kwargs):
         begin = time.time()
         r = await f(*args, **kwargs)
         end = time.time()
-        logger.info(dict(name=f.__name__, duration=end - begin, meta=meta))
+        _log(f, begin, end)
         return r
 
     if iscoroutinefunction(f):

--- a/tests/common/test_timeit.py
+++ b/tests/common/test_timeit.py
@@ -1,0 +1,56 @@
+from typing import Any
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import ANY, MagicMock, patch
+from clubbi_utils.json_logging import JsonLogger
+from clubbi_utils.common import timeit
+
+
+class TestTimeit(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._jlogger_mock = MagicMock(spec=JsonLogger)
+        self._jlogger_patch = patch("clubbi_utils.common.timeit.jlogger", self._jlogger_mock)
+        self._jlogger_patch.start()
+
+    def tearDown(self) -> None:
+        self._jlogger_patch.stop()
+        super().tearDown()
+
+    def _get_jlogger_info_call(self) -> dict[str, Any]:
+        self._jlogger_mock.info.assert_called_once()
+        _, kwargs = self._jlogger_mock.info.call_args_list[0]
+        return kwargs
+
+    async def test_async_function(self) -> None:
+        @timeit.with_timeit
+        async def asyncfunc() -> None:
+            return
+
+        await asyncfunc()
+        self.assertEqual(
+            self._get_jlogger_info_call(),
+            {
+                "duration": ANY,
+                "meta": {
+                    "module": "test_timeit",
+                    "qualname": "TestTimeit.test_async_function.<locals>.asyncfunc",
+                },
+            },
+        )
+
+    def test_sync_function(self) -> None:
+        @timeit.with_timeit
+        def syncfunc() -> None:
+            return
+
+        syncfunc()
+        self.assertEqual(
+            self._get_jlogger_info_call(),
+            {
+                "duration": ANY,
+                "meta": {
+                    "module": "test_timeit",
+                    "qualname": "TestTimeit.test_sync_function.<locals>.syncfunc",
+                },
+            },
+        )


### PR DESCRIPTION
### Qual o propósito deste pull request?
Faz o logging do with_timeit utilizar o jlogger ao invés do logger.info

 ### Como esta mudança deve ser testada?
 Usar o decorator with_timeit e verificar os logs do mesmo
