### PR TITLE
feat: parse_obj_list_with_errors

### DIFF
--- a/clubbi_utils/common/clubbi_validation_error.py
+++ b/clubbi_utils/common/clubbi_validation_error.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+from typing import Any, Optional, TypedDict
+
+
+class ErrorUnit(TypedDict):
+    identifier: Optional[str]
+    msg: str
+    loc: str
+    type: str
+
+
+@dataclass
+class ClubbiValidationError(Exception):
+    errors: list[ErrorUnit]
+    model: str
+
+    def dict(self) -> dict[str, Any]:
+        return dict(
+            errors=self.errors,
+            model=self.model,
+        )

--- a/clubbi_utils/common/parse_obj_list_with_errors.py
+++ b/clubbi_utils/common/parse_obj_list_with_errors.py
@@ -1,0 +1,77 @@
+from typing import Optional, Type, TypeVar, Any
+
+from pydantic import parse_obj_as, ValidationError
+
+from clubbi_utils.common.clubbi_validation_error import ClubbiValidationError, ErrorUnit
+
+T = TypeVar("T")
+
+
+def parse_obj_list_with_errors(type_: Type[T], obj: Any) -> tuple[list[T], Optional[ClubbiValidationError]]:
+    """Parses a list of `obj` given a type `T` and returns a tuple containing the parsed result and errors,
+    if a parsing error occurs the current value will be skiped and it's error will be appended in the errors result.
+
+    Example:
+    ```python
+    from pydantic import BaseModel
+    from clubbi_utils.common.parse_obj_list_with_errors import parse_obj_list_with_errors
+    from clubbi_utils.common.clubbi_validation_error import ClubbiValidationError
+
+
+    class Foo(BaseModel):
+        a: int
+
+
+    data = [{"a": 1}, {"a": "not a number"}, {"a": 2}]
+    parsed_values, error = parse_obj_list_with_errors(Foo, data)
+
+    assert parsed_values == [Foo(a=1), Foo(a=2)]
+    assert error ==  ClubbiValidationError(
+        errors=[
+            {
+                "identifier": "linha 2",
+                "msg": "value is not a valid integer",
+                "loc": "a",
+                "type": "type_error.integer",
+            }
+        ],
+        model="Foo",
+    )
+    ```
+    """
+
+    parsed_values: list[T] = []
+    errors: list[ErrorUnit] = []
+    type_qualname = type_.__qualname__
+    if not isinstance(obj, list):
+        validation_error = ClubbiValidationError(
+            errors=[
+                ErrorUnit(
+                    identifier="0",
+                    msg="Obj is not a list",
+                    loc="0",
+                    type="ValidationError",
+                )
+            ],
+            model=type_qualname,
+        )
+        return [], validation_error
+    for row_number, datum in enumerate(obj):
+        try:
+            parsed_value = parse_obj_as(type_, datum)
+            parsed_values.append(parsed_value)
+        except ValidationError as e:
+            errors.extend(
+                [
+                    ErrorUnit(
+                        identifier=f"linha {row_number + 1}",
+                        msg=error["msg"],
+                        loc=".".join(str(loc) for loc in error["loc"][1:]),
+                        type=error["type"],
+                    )
+                    for error in e.errors()
+                ]
+            )
+    if errors:
+        return parsed_values, ClubbiValidationError(errors=errors, model=type_qualname)
+    return parsed_values, None

--- a/tests/common/test_parse_obj_list_with_errors.py
+++ b/tests/common/test_parse_obj_list_with_errors.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+
+from pydantic import BaseModel
+from clubbi_utils.common.clubbi_validation_error import ClubbiValidationError
+
+from clubbi_utils.common.parse_obj_list_with_errors import parse_obj_list_with_errors
+
+
+class Foo(BaseModel):
+    a: int
+
+
+class TestParseObjListWithErrors(TestCase):
+    def test_parse_no_errors(self) -> None:
+        data = [{"a": 1}, {"a": 2}]
+        parsed_values, error = parse_obj_list_with_errors(Foo, data)
+        self.assertEqual(parsed_values, [Foo(a=1), Foo(a=2)])
+        self.assertIsNone(error)
+
+    def test_parse_with_errors(self) -> None:
+        data = [{"a": 1}, {"a": "not a number"}, {"a": 2}]
+        parsed_values, error = parse_obj_list_with_errors(Foo, data)
+        self.assertEqual(parsed_values, [Foo(a=1), Foo(a=2)])
+        self.assertEqual(
+            error,
+            ClubbiValidationError(
+                errors=[
+                    {
+                        "identifier": "linha 2",
+                        "msg": "value is not a valid integer",
+                        "loc": "a",
+                        "type": "type_error.integer",
+                    }
+                ],
+                model="Foo",
+            ),
+        )
+
+    def test_parse_obj_not_list(self) -> None:
+        parsed_values, error = parse_obj_list_with_errors(Foo, {})
+        self.assertEqual(parsed_values, [])
+        self.assertEqual(
+            error,
+            ClubbiValidationError(
+                errors=[{"identifier": "0", "msg": "Obj is not a list", "loc": "0", "type": "ValidationError"}],
+                model="Foo",
+            ),
+        )


### PR DESCRIPTION
### Qual o propósito deste pull request?
Adiciona método `parse_obj_with_errors` no qual faz um parsing com recuperação de erros dado um base model, exemplo:
```python
from pydantic import BaseModel
from clubbi_utils.common.parse_obj_list_with_errors import parse_obj_list_with_errors
from clubbi_utils.common.clubbi_validation_error import ClubbiValidationError


class Foo(BaseModel):
    a: int


data = [{"a": 1}, {"a": "not a number"}, {"a": 2}]
parsed_values, error = parse_obj_list_with_errors(Foo, data)

assert parsed_values == [Foo(a=1), Foo(a=2)]
assert error ==  ClubbiValidationError(
    errors=[
        {
            "identifier": "linha 2",
            "msg": "value is not a valid integer",
            "loc": "a",
            "type": "type_error.integer",
        }
    ],
    model="Foo",
)
```
 ### Como esta mudança deve ser testada?
 Testar exemplo
