### PR TITLE
feat: br_date

### DIFF
--- a/clubbi_utils/common/pydantic_types.py
+++ b/clubbi_utils/common/pydantic_types.py
@@ -13,8 +13,7 @@ class BrDate(date):
             return value
         if isinstance(value, str):
             return datetime.strptime(value, "%d/%m/%Y").date()
-        else:
-            raise ValueError(f"Unrecognized type {value}")
+        raise ValueError(f"Unrecognized type {value}")
 
 
 BrCompatibleDate = Union[BrDate, date]

--- a/clubbi_utils/common/pydantic_types.py
+++ b/clubbi_utils/common/pydantic_types.py
@@ -1,10 +1,10 @@
 from datetime import date, datetime
-from typing import Any, Callable, Union
+from typing import Any, Callable, Generator, Union
 
 
 class BrDate(date):
     @classmethod
-    def __get_validators__(cls) -> Callable[[Any], date]:
+    def __get_validators__(cls) -> Generator[Callable[[Any], date], None, None]:
         yield cls._validate
 
     @classmethod

--- a/clubbi_utils/common/pydantic_types.py
+++ b/clubbi_utils/common/pydantic_types.py
@@ -1,0 +1,20 @@
+from datetime import date, datetime
+from typing import Any, Callable, Union
+
+
+class BrDate(date):
+    @classmethod
+    def __get_validators__(cls) -> Callable[[Any], date]:
+        yield cls._validate
+
+    @classmethod
+    def _validate(cls, value: Any) -> date:
+        if isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            return datetime.strptime(value, "%d/%m/%Y").date()
+        else:
+            raise ValueError(f"Unrecognized type {value}")
+
+
+BrCompatibleDate = Union[BrDate, date]

--- a/tests/common/test_pydatinc_types.py
+++ b/tests/common/test_pydatinc_types.py
@@ -22,7 +22,7 @@ class TestPydanticTypes(TestCase):
         self.assertEqual(foo, Foo(date1=date(2022, 12, 20), date2=None))
 
         with self.assertRaises(ValidationError):
-            foo = Foo.parse_obj(
+            Foo.parse_obj(
                 {
                     "date1": "2022/12/20",
                     "date2": None,
@@ -46,7 +46,7 @@ class TestPydanticTypes(TestCase):
         self.assertEqual(foo, Foo(date1=date(2022, 12, 20), date2=date(2022, 12, 20), date3=None))
 
         with self.assertRaises(ValidationError):
-            foo = Foo.parse_obj(
+            Foo.parse_obj(
                 {
                     "date1": "2022/12/20",
                     "date2": "2022-12-20",

--- a/tests/common/test_pydatinc_types.py
+++ b/tests/common/test_pydatinc_types.py
@@ -1,0 +1,55 @@
+from datetime import date
+from typing import Optional
+from unittest import TestCase
+
+from pydantic import BaseModel, ValidationError
+
+from clubbi_utils.common.pydantic_types import BrCompatibleDate, BrDate
+
+
+class TestPydanticTypes(TestCase):
+    def test_br_date(self) -> None:
+        class Foo(BaseModel):
+            date1: BrDate
+            date2: Optional[BrDate]
+
+        foo = Foo.parse_obj(
+            {
+                "date1": "20/12/2022",
+                "date2": None,
+            }
+        )
+        self.assertEqual(foo, Foo(date1=date(2022, 12, 20), date2=None))
+
+        with self.assertRaises(ValidationError):
+            foo = Foo.parse_obj(
+                {
+                    "date1": "2022/12/20",
+                    "date2": None,
+                }
+            )
+
+    def test_br_compatible_date(self) -> None:
+        class Foo(BaseModel):
+            date1: Optional[BrCompatibleDate]
+            date2: Optional[BrCompatibleDate]
+            date3: Optional[BrCompatibleDate]
+
+        foo = Foo.parse_obj(
+            {
+                "date1": "20/12/2022",
+                "date2": "2022-12-20",
+                "date3": None,
+            }
+        )
+
+        self.assertEqual(foo, Foo(date1=date(2022, 12, 20), date2=date(2022, 12, 20), date3=None))
+
+        with self.assertRaises(ValidationError):
+            foo = Foo.parse_obj(
+                {
+                    "date1": "2022/12/20",
+                    "date2": "2022-12-20",
+                    "date3": None,
+                }
+            )


### PR DESCRIPTION
### Qual o propósito deste pull request?
Adiciona tipos `BrDate` e `BrCompatibleDate` que fazem o parse de datas do pydantic utilzando o formato brasileiro ou brasileiro/ISO 8601

### Como esta mudança deve ser testada?
Testes unitários cobrem isso

