### PR TITLE
fix/mysql retry on deadlock

### DIFF
--- a/clubbi_utils/mysql/retry_query_on_deadlock.py
+++ b/clubbi_utils/mysql/retry_query_on_deadlock.py
@@ -23,19 +23,18 @@ async def retry_query_on_deadlock(
     error: Exception
     for attempt in range(maximum_number_of_retries):
         async with engine.begin() as conn:
-            async with conn.begin_nested():
-                try:
-                    return await conn.execute(statement, parameters)
-                except OperationalError as operror:
-                    if not is_deadlock_error(operror):
-                        raise
-                    jlogger.warning(
-                        "retry_query_on_deadlock",
-                        "deadlock_error",
-                        str_err=str(operror),
-                        repr_err=repr(operror),
-                        traceback=traceback.format_exc(),
-                        attempt=attempt + 1,
-                    )
-                    error = operror
+            try:
+                return await conn.execute(statement, parameters)
+            except OperationalError as operror:
+                if not is_deadlock_error(operror):
+                    raise
+                jlogger.warning(
+                    "retry_query_on_deadlock",
+                    "deadlock_error",
+                    str_err=str(operror),
+                    repr_err=repr(operror),
+                    traceback=traceback.format_exc(),
+                    attempt=attempt + 1,
+                )
+                error = operror
     raise error


### PR DESCRIPTION
### Qual o propósito deste pull request?
Conserta problema com retry_on_deadlock do mysql onde begin_nested não é necessário.

 ### Como esta mudança deve ser testada?
Testes cobrem isso

